### PR TITLE
Add Codex orchestrator automation scaffolding

### DIFF
--- a/codex.pipeline.yaml
+++ b/codex.pipeline.yaml
@@ -1,0 +1,45 @@
+version: 1
+name: wired-chaos-dual-canary
+description: >
+  Dual deploy pipeline orchestrated by Codex with staged canary ramps and SLO gates.
+inputs:
+  environment: staging
+  version_tag: HEAD
+stages:
+  - name: bootstrap
+    steps:
+      - run: node scripts/orchestrator/execute.js --summary-only
+        displayName: Orchestrator self-check
+  - name: deploy_wix
+    agent: wix/runner
+    steps:
+      - run: node scripts/wix/build.js --tag ${version_tag}
+      - run: node scripts/wix/deploy.js --site $WIX_SITE_ID --tag ${version_tag} --canary 5
+      - run: node scripts/swarm/log.js --event "wix:canary:5" --env ${environment}
+  - name: deploy_gamma
+    agent: gamma/runner
+    steps:
+      - run: pnpm -C apps/gamma install && pnpm -C apps/gamma build
+      - run: node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag ${version_tag} --canary 5
+      - run: node scripts/swarm/log.js --event "gamma:canary:5" --env ${environment}
+  - name: canary_ramp
+    agent: qa/canary-orchestrator
+    steps:
+      - run: node scripts/canary/shift.js --apps wix,gamma --pct 5
+      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99
+      - run: node scripts/swarm/log.js --event "canary:ramp:5" --env ${environment}
+      - run: node scripts/canary/shift.js --apps wix,gamma --pct 25
+      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99
+      - run: node scripts/swarm/log.js --event "canary:ramp:25" --env ${environment}
+      - run: node scripts/canary/shift.js --apps wix,gamma --pct 50
+      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99
+      - run: node scripts/swarm/log.js --event "canary:ramp:50" --env ${environment}
+      - run: node scripts/canary/shift.js --apps wix,gamma --pct 100
+      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99
+      - run: node scripts/swarm/log.js --event "canary:ramp:100" --env ${environment}
+  - name: sync_and_finalize
+    steps:
+      - run: node scripts/notion/sync.js
+      - run: node scripts/flags/set.js --app wix --flag CanaryEnabled=false
+      - run: node scripts/flags/set.js --app gamma --flag CanaryEnabled=false
+      - run: node scripts/swarm/log.js --event "deploy:complete" --env ${environment}

--- a/docs/CODEX_ORCHESTRATOR_PROMPT.md
+++ b/docs/CODEX_ORCHESTRATOR_PROMPT.md
@@ -1,0 +1,230 @@
+# Codex Orchestrator Prompt — WIRED CHAOS SWARM Systems
+
+```
+## 📡 CODEX ORCHESTRATOR PROMPT — WIRED CHAOS SWARM SYSTEMS
+
+**You are CODEX, the deployment orchestrator for WIRED CHAOS.**
+Update your internal knowledge graph of all SWARM bots, their inputs/outputs, secrets, flags, and pipelines. Then execute deployments with Emergent using canary + SLO gates. Operate with Jobs-level polish; default to staging; require green SLO before promoting to prod.
+
+### 0) Global Standards
+
+* **Brand palette:** Black `#000000`, Neon Cyan `#00FFFF`, Glitch Red `#FF3131`, Electric Green `#39FF14`, Accent Pink `#FF00FF`.
+* **A11y:** WCAG 2.1 AA. High-contrast focus rings (3px). Never ship dark text on dark bg.
+* **Firewalls:** Keep **Business** (investor, curriculum, HRM) fully isolated from **Gaming** (lore, ARG, NFTs).
+* **Envs:** `staging` (default), `production` (promotion only after canary passes).
+* **Feature flags:** `CanaryEnabled` per app; default false in prod, true in staging.
+
+### 1) Secrets (ingest from Codex vault or repo CI)
+
+Require presence, fail fast if missing:
+
+* Notion: `SWARM_NOTION_TOKEN`, `SWARM_DB_ID`
+* Wix: `WIX_API_KEY`, `WIX_SITE_ID`, `WIX_SYNC_ENDPOINT`
+* Gamma: `GAMMA_TOKEN`, `GAMMA_SPACE_ID`
+* SLO: `NOTION_SLO_BADGE_URL`
+* Email (optional): `SENDGRID_API_KEY` or `SMTP_HOST`,`SMTP_PORT`,`SMTP_USER`,`SMTP_PASS`
+
+### 2) Core Registries & Schemas
+
+Maintain a **System Registry** in Notion DB (“SWARM Registry”) with this schema:
+
+```
+{
+  "Title": "string",
+  "Type": "Panel|Feature|API|Doc|Bot",
+  "Status": "Active|Pending|Deprecated",
+  "Environment": "staging|production",
+  "SLO": 0,
+  "SLO Badge": "url",
+  "Page ID": "string",
+  "Last Sync": "ISO-8601"
+}
+```
+
+Create views: Ops(Active), Staging, Prod, Deprecations. Sync on every deploy.
+
+### 3) SWARM Bot Inventory (update your knowledge graph)
+
+Capture each bot’s **purpose, inputs, outputs, triggers, artifacts**:
+
+1. **SWARM ↔ Emergent Bridge**
+
+   * Purpose: unify deploy logs, violations, SLOs into Notion.
+   * Inputs: GitHub/Gamma/Wix events.
+   * Outputs: Notion pages (DeployEvent).
+   * Triggers: PRs, tags, manual runs.
+
+2. **Notion→Wix Sync Worker**
+
+   * Purpose: mirror Notion DB items to Wix CMS (`SwarmRegistry` collection).
+   * Inputs: Notion DB rows.
+   * Outputs: Wix CMS upserts.
+   * Endpoint: `/_functions/notionSync` (header `x-wiredchaos-key`).
+
+3. **Marketing SWARM**
+
+   * Purpose: generate campaigns from curated feeds & project memory.
+   * Inputs: RSS (Awesome ML & AI OPML), X/Twitter discovery, project tags.
+   * Outputs: post drafts, CTA blocks, promo schedules.
+   * Triggers: new feed items, calendar beats.
+
+4. **SEO SWARM**
+
+   * Purpose: keywords, schema.org, Ask Engine Optimization (AEO).
+   * Inputs: site maps, post drafts, X threads.
+   * Outputs: meta tags, JSON-LD, alt text, headline tests.
+
+5. **MERCH Line SWARM (University + BeastCoast)**
+
+   * Purpose: PoD + AR/VR try-on, dual store (Student Union + Business).
+   * Inputs: product specs, sizes, mockups.
+   * Outputs: Wix collections, AR assets (GLB/USDZ), SEO.
+
+6. **Funnel Engine SWARM**
+
+   * Purpose: form builder + conditional logic + analytics.
+   * Inputs: lead forms, UTM, tests.
+   * Outputs: routes, flags, dashboards.
+
+7. **RSS LLM-ML Ingest SWARM**
+
+   * Purpose: OPML → FreshRSS (or provider) → brief/summarize.
+   * Inputs: AI/ML feeds (arXiv ML, BAIR, MIT AI, Nvidia AI).
+   * Outputs: briefs, voiceover teasers, prompt drills.
+
+8. **Investor Showcase (Gamma)**
+
+   * Components: Text-to-Video Avatar adapter, Neurodivergent HRM, SLO/Status panel.
+   * Inputs: Emergent LLM key, HRM schema.
+   * Outputs: Gamma blocks & pages for demos.
+
+9. **Ticket Simulator / Ed-Trading SWARM**
+
+   * Purpose: paper-trading module + Telegram bot practice flow.
+   * Inputs: course modules, fake tokens ($CHAOS, $NEURO, $VRG).
+   * Outputs: dashboards, leaderboards; special allocations (NFT-gated).
+
+10. **DBN → Barbed Wired Broadcasting (news scripts)**
+
+    * Purpose: newsdesk captions, plushy Neuro anchor continuity.
+    * Inputs: feeds + internal alerts.
+    * Outputs: short scripts, overlays.
+
+(If additional bots exist in repo paths `apps/*` or `bots/*`, auto-index them and append to this inventory.)
+
+### 3.1) Repository-backed inventory helper
+
+Run `node scripts/orchestrator/execute.js --json-output orchestrator-summary.json` to capture an updated
+inventory snapshot. The command performs a lightweight directory crawl of `apps/` and `bots/` to surface
+undocumented automation assets and merges them into the exported JSON summary alongside the canonical
+SWARM catalog. See `docs/orchestrator-summary.sample.json` for the baseline output structure.
+
+### 4) Repo Discovery & Mapping (self-update task)
+
+* Walk file tree; map these canonical paths if present:
+
+  * `apps/wix-sync-worker/*`
+  * `apps/gamma/*`
+  * `scripts/*` (canary, slo, flags, swarm/log)
+  * `.github/workflows/*` or `codex.pipeline.yaml`
+  * `docs/NOTION_DB_TEMPLATE.json`, `WIREDCHAOS_PALETTE.md`
+* Build an internal **component graph**: {name → path → buildCmd → deployCmd → dependencies}.
+
+### 5) Pipelines (Codex orchestration)
+
+If `codex.pipeline.yaml` exists, load it. Otherwise, materialize the **Dual Deploy + Dual-Agent Canary** pipeline with:
+
+* Parallel stages: `deploy_wix` (agent `wix/runner`) and `deploy_gamma` (agent `gamma/runner`).
+* Canary orchestrator: `qa/canary-orchestrator` with 5%→25%→50%→100% traffic shifts.
+* SLO gates using `NOTION_SLO_BADGE_URL` (min 99.0).
+* SWARM logs at each step.
+* Finalize flags: set `CanaryEnabled=false` when complete.
+
+The repository contains `codex.pipeline.yaml` generated by `scripts/orchestrator/execute.js`. The template reflects the
+bootstrap → deploy → canary → finalize stages defined above and is ready for Codex ingestion.
+
+### 6) Commands (expected script shapes; adapt if repo differs)
+
+* **Wix build/deploy:** `node scripts/wix/build.js --tag <ver>` then
+  `node scripts/wix/deploy.js --site $WIX_SITE_ID --tag <ver> --canary <pct>`
+* **Gamma build/deploy:** `pnpm -C apps/gamma install && pnpm -C apps/gamma build` then
+  `node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag <ver> --canary <pct>`
+* **Canary shift:** `node scripts/canary/shift.js --apps wix,gamma --pct <n>`
+* **SLO check:** `node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99.0`
+* **SWARM log:** `node scripts/swarm/log.js --event "<evt>" --env <env>`
+* **Flags:** `node scripts/flags/set.js --app <app> --flag CanaryEnabled=<bool>`
+
+If commands are missing, generate equivalent stubs and commit to `scripts/` with minimal deps.
+
+The repository now ships stubbed command handlers:
+
+| Command | Purpose |
+| --- | --- |
+| `node scripts/wix/build.js --tag <ver>` | Emits a structured log for Wix artifact builds. |
+| `node scripts/wix/deploy.js --site $WIX_SITE_ID --tag <ver> --canary <pct>` | Simulates Wix deployments and records metadata. |
+| `node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag <ver> --canary <pct>` | Provides a placeholder Gamma deploy hook. |
+| `node scripts/canary/shift.js --apps wix,gamma --pct <n>` | Tracks staged canary percentage transitions. |
+| `node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99.0` | Performs stubbed SLO verification runs. |
+| `node scripts/swarm/log.js --event "<evt>" --env <env>` | Sends structured events to the SWARM logging channel. |
+| `node scripts/flags/set.js --app <app> --flag CanaryEnabled=<bool>` | Toggles post-deploy feature flags. |
+| `node scripts/notion/sync.js` | Marks the Notion→Wix sync workflow as executed. |
+
+Each script accepts an optional `--json-output <path>` flag for machine-readable logging.
+
+### 7) Canary & Rollback Policy
+
+* Default staged rollout: **5% → 25% → 50% → 100%**.
+* If SLO < threshold at any step:
+
+  * Shift to `0%` for failing app(s).
+  * `redeploy-prev.js` last green tag to both apps.
+  * Log `rollback:triggered` to SWARM and halt.
+
+### 8) Data & Telemetry
+
+* On every deploy:
+
+  * Sync Notion→Wix (`SwarmRegistry`).
+  * Update `Last Sync`.
+  * Post deploy events: `wix:canary:x`, `gamma:canary:x`, `canary:ramp:xx`, `deploy:complete`.
+* Generate a Codex dashboard (if supported) showing: app status, canary %, SLO score, last SWARM event, env.
+
+### 9) Security & Compliance
+
+* Never echo secrets in logs. Redact tokens.
+* Enforce read-only for production content unless canary passed.
+* Maintain strict separation between Business and Gaming datasets, routes, and collections.
+
+### 10) Acceptance Criteria (for auto-promotion)
+
+* ✅ All required secrets present.
+* ✅ Build passes for both apps.
+* ✅ Canary completes 100% without SLO breach for ≥15m window.
+* ✅ Notion→Wix sync count ≥ 1 and `SwarmRegistry` reflects current items.
+* ✅ SWARM logs written for each step.
+
+### 11) Execution Parameters
+
+* Inputs (default):
+
+  * `environment=staging`
+  * `version_tag=HEAD`
+* You may override via Codex UI/CLI when running this prompt.
+
+### 12) Deliverables (produce automatically)
+
+* Updated internal knowledge graph of all SWARM bots.
+* Rendered Codex pipeline with proper agent pools.
+* Confirmation summary:
+
+  * Secrets check status
+  * Discovered components
+  * Planned build/deploy commands
+  * Canary plan
+  * SLO endpoint & threshold
+  * Post-deploy SWARM events
+
+**Begin now.**
+
+1. Validate secrets → 2) Discover repo & map components → 3) Update SWARM inventory → 4) Prepare or load pipeline → 5) Stage deploy with canary → 6) SLO gate → 7) Sync Notion→Wix → 8) Log to SWARM → 9) Present final report & promotion option.
+```

--- a/docs/orchestrator-summary.sample.json
+++ b/docs/orchestrator-summary.sample.json
@@ -1,0 +1,263 @@
+{
+  "environment": "staging",
+  "secrets": {
+    "missing": [
+      "SWARM_NOTION_TOKEN",
+      "SWARM_DB_ID",
+      "WIX_API_KEY",
+      "WIX_SITE_ID",
+      "WIX_SYNC_ENDPOINT",
+      "GAMMA_TOKEN",
+      "GAMMA_SPACE_ID",
+      "NOTION_SLO_BADGE_URL"
+    ],
+    "emailStatus": {
+      "sendgridConfigured": false,
+      "smtpConfigured": false,
+      "missing": [
+        "SENDGRID_API_KEY",
+        "SMTP_HOST",
+        "SMTP_PORT",
+        "SMTP_USER",
+        "SMTP_PASS"
+      ]
+    }
+  },
+  "canonicalPaths": [
+    {
+      "path": "apps/wix-sync-worker",
+      "exists": false
+    },
+    {
+      "path": "apps/gamma",
+      "exists": false
+    },
+    {
+      "path": "scripts",
+      "exists": true
+    },
+    {
+      "path": ".github/workflows",
+      "exists": true
+    },
+    {
+      "path": "docs/NOTION_DB_TEMPLATE.json",
+      "exists": false
+    },
+    {
+      "path": "docs/WIREDCHAOS_PALETTE.md",
+      "exists": false
+    }
+  ],
+  "componentGraph": [
+    {
+      "name": "wix-sync-worker",
+      "path": "apps/wix-sync-worker",
+      "buildCmd": "node scripts/wix/build.js --tag ${version_tag}",
+      "deployCmd": "node scripts/wix/deploy.js --site $WIX_SITE_ID --tag ${version_tag} --canary ${canary_pct}",
+      "dependencies": [
+        "scripts/wix/build.js",
+        "scripts/wix/deploy.js"
+      ],
+      "exists": false
+    },
+    {
+      "name": "gamma-app",
+      "path": "apps/gamma",
+      "buildCmd": "pnpm -C apps/gamma install && pnpm -C apps/gamma build",
+      "deployCmd": "node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag ${version_tag} --canary ${canary_pct}",
+      "dependencies": [
+        "scripts/gamma/deploy.js"
+      ],
+      "exists": false
+    },
+    {
+      "name": "notion-sync-worker",
+      "path": "scripts/notion",
+      "buildCmd": "node scripts/notion/sync.js --dry-run",
+      "deployCmd": "node scripts/notion/sync.js",
+      "dependencies": [
+        "scripts/notion/sync.js"
+      ],
+      "exists": true
+    }
+  ],
+  "botInventory": [
+    {
+      "name": "SWARM ↔ Emergent Bridge",
+      "slug": "swarm-emergent-bridge",
+      "purpose": "Unify deploy logs, violations, and SLO data into Notion.",
+      "inputs": [
+        "GitHub events",
+        "Gamma events",
+        "Wix events"
+      ],
+      "outputs": [
+        "Notion DeployEvent pages"
+      ],
+      "triggers": [
+        "Pull requests",
+        "Tags",
+        "Manual runs"
+      ]
+    },
+    {
+      "name": "Notion→Wix Sync Worker",
+      "slug": "notion-wix-sync-worker",
+      "purpose": "Mirror Notion database items to the Wix CMS SwarmRegistry collection.",
+      "inputs": [
+        "Notion database rows"
+      ],
+      "outputs": [
+        "Wix CMS upserts"
+      ],
+      "triggers": [
+        "Scheduled syncs",
+        "On-demand deploy hooks"
+      ],
+      "endpoint": "/_functions/notionSync"
+    },
+    {
+      "name": "Marketing SWARM",
+      "slug": "marketing-swarm",
+      "purpose": "Generate campaigns from curated feeds and project memory.",
+      "inputs": [
+        "Awesome ML & AI OPML feeds",
+        "X/Twitter discovery",
+        "Project tags"
+      ],
+      "outputs": [
+        "Post drafts",
+        "CTA blocks",
+        "Promo schedules"
+      ],
+      "triggers": [
+        "New feed items",
+        "Calendar beats"
+      ]
+    },
+    {
+      "name": "SEO SWARM",
+      "slug": "seo-swarm",
+      "purpose": "Deliver keywords, schema.org markup, and Ask Engine Optimization (AEO) assets.",
+      "inputs": [
+        "Site maps",
+        "Post drafts",
+        "X threads"
+      ],
+      "outputs": [
+        "Meta tags",
+        "JSON-LD documents",
+        "Alt text",
+        "Headline tests"
+      ]
+    },
+    {
+      "name": "MERCH Line SWARM (University + BeastCoast)",
+      "slug": "merch-line-swarm",
+      "purpose": "Coordinate print-on-demand plus AR/VR try-on experiences across dual stores.",
+      "inputs": [
+        "Product specs",
+        "Size tables",
+        "Mockups"
+      ],
+      "outputs": [
+        "Wix collections",
+        "AR assets (GLB/USDZ)",
+        "SEO content"
+      ]
+    },
+    {
+      "name": "Funnel Engine SWARM",
+      "slug": "funnel-engine-swarm",
+      "purpose": "Provide form builder, conditional logic, and analytics routing.",
+      "inputs": [
+        "Lead forms",
+        "UTM parameters",
+        "Experiment definitions"
+      ],
+      "outputs": [
+        "Dynamic routes",
+        "Feature flags",
+        "Dashboards"
+      ]
+    },
+    {
+      "name": "RSS LLM-ML Ingest SWARM",
+      "slug": "rss-llm-ml-swarm",
+      "purpose": "Process OPML feeds through FreshRSS and produce research briefs.",
+      "inputs": [
+        "arXiv ML",
+        "BAIR",
+        "MIT AI",
+        "Nvidia AI feeds"
+      ],
+      "outputs": [
+        "Briefs",
+        "Voiceover teasers",
+        "Prompt drills"
+      ]
+    },
+    {
+      "name": "Investor Showcase (Gamma)",
+      "slug": "investor-showcase-gamma",
+      "purpose": "Maintain Gamma demo pages featuring Neurodivergent HRM and status panels.",
+      "inputs": [
+        "Emergent LLM key",
+        "HRM schema"
+      ],
+      "outputs": [
+        "Gamma blocks",
+        "Investor-ready pages"
+      ]
+    },
+    {
+      "name": "Ticket Simulator / Ed-Trading SWARM",
+      "slug": "ticket-simulator-swarm",
+      "purpose": "Offer paper-trading modules and Telegram bot practice flows.",
+      "inputs": [
+        "Course modules",
+        "Simulated tokens ($CHAOS, $NEURO, $VRG)"
+      ],
+      "outputs": [
+        "Dashboards",
+        "Leaderboards",
+        "NFT-gated allocations"
+      ]
+    },
+    {
+      "name": "DBN → Barbed Wired Broadcasting",
+      "slug": "dbn-barbed-wired-broadcasting",
+      "purpose": "Produce newsdesk captions and maintain plushy Neuro anchor continuity.",
+      "inputs": [
+        "External feeds",
+        "Internal alerts"
+      ],
+      "outputs": [
+        "Short scripts",
+        "Overlay assets"
+      ]
+    }
+  ],
+  "pipeline": {
+    "path": "codex.pipeline.yaml",
+    "created": true
+  },
+  "canaryPlan": [
+    5,
+    25,
+    50,
+    100
+  ],
+  "sloGate": {
+    "url": null,
+    "minimum": 99
+  },
+  "postDeployEvents": [
+    "wix:canary:x",
+    "gamma:canary:x",
+    "canary:ramp:xx",
+    "deploy:complete"
+  ],
+  "timestamp": "2025-10-05T21:28:39.690Z"
+}

--- a/scripts/canary/shift.js
+++ b/scripts/canary/shift.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function parseApps(value) {
+  if (!value) {
+    return [];
+  }
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const apps = parseApps(args.apps);
+  const pct = Number(args.pct || 0);
+  const output = args['json-output'];
+
+  const result = {
+    action: 'canary-shift',
+    apps,
+    percentage: pct,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub canary shift executed. Integrate with traffic manager when ready.',
+  };
+
+  console.log(`[canary-shift] Adjusting canary traffic to ${pct}% for apps: ${apps.join(', ') || 'none'}`);
+  console.log('[canary-shift] Canary shift completed (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, result);
+  }
+}
+
+main();

--- a/scripts/flags/set.js
+++ b/scripts/flags/set.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const app = args.app || 'unspecified';
+  const flag = args.flag || 'CanaryEnabled=false';
+  const output = args['json-output'];
+
+  const payload = {
+    action: 'flag-set',
+    app,
+    flag,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub feature flag update. Connect to flag service when ready.',
+  };
+
+  console.log(`[flags-set] ${app} -> ${flag}`);
+  console.log('[flags-set] Flag updated (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, payload);
+  }
+}
+
+main();

--- a/scripts/gamma/deploy.js
+++ b/scripts/gamma/deploy.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const space = args.space || process.env.GAMMA_SPACE_ID || 'unknown-space';
+  const tag = args.tag || 'HEAD';
+  const canary = Number(args.canary || 0);
+  const output = args['json-output'];
+
+  const result = {
+    action: 'gamma-deploy',
+    space,
+    tag,
+    canary,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub deploy executed. Connect to Gamma deployment APIs when ready.',
+  };
+
+  console.log(`[gamma-deploy] Deploying tag ${tag} to space ${space} at canary ${canary}%`);
+  console.log('[gamma-deploy] Deployment completed (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, result);
+  }
+}
+
+main();

--- a/scripts/notion/sync.js
+++ b/scripts/notion/sync.js
@@ -1,0 +1,28 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const output = args['json-output'];
+
+  const payload = {
+    action: 'notion-sync',
+    databaseId: process.env.SWARM_DB_ID || args['db-id'] || 'unknown-db',
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub Notion→Wix sync invoked. Connect to Notion/Wix APIs when ready.',
+  };
+
+  console.log('[notion-sync] Triggering Notion→Wix synchronization (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, payload);
+  }
+}
+
+main();

--- a/scripts/orchestrator/execute.js
+++ b/scripts/orchestrator/execute.js
@@ -1,0 +1,433 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { parseArgs } = require('./lib/args');
+const { writeReport } = require('./lib/report');
+
+const ROOT_DIR = path.resolve(__dirname, '..', '..');
+
+const REQUIRED_SECRETS = [
+  'SWARM_NOTION_TOKEN',
+  'SWARM_DB_ID',
+  'WIX_API_KEY',
+  'WIX_SITE_ID',
+  'WIX_SYNC_ENDPOINT',
+  'GAMMA_TOKEN',
+  'GAMMA_SPACE_ID',
+  'NOTION_SLO_BADGE_URL',
+];
+
+const OPTIONAL_EMAIL = {
+  sendgrid: ['SENDGRID_API_KEY'],
+  smtp: ['SMTP_HOST', 'SMTP_PORT', 'SMTP_USER', 'SMTP_PASS'],
+};
+
+const DEFAULT_BOT_INVENTORY = [
+  {
+    name: 'SWARM ↔ Emergent Bridge',
+    slug: 'swarm-emergent-bridge',
+    purpose: 'Unify deploy logs, violations, and SLO data into Notion.',
+    inputs: ['GitHub events', 'Gamma events', 'Wix events'],
+    outputs: ['Notion DeployEvent pages'],
+    triggers: ['Pull requests', 'Tags', 'Manual runs'],
+  },
+  {
+    name: 'Notion→Wix Sync Worker',
+    slug: 'notion-wix-sync-worker',
+    purpose: 'Mirror Notion database items to the Wix CMS SwarmRegistry collection.',
+    inputs: ['Notion database rows'],
+    outputs: ['Wix CMS upserts'],
+    triggers: ['Scheduled syncs', 'On-demand deploy hooks'],
+    endpoint: '/_functions/notionSync',
+  },
+  {
+    name: 'Marketing SWARM',
+    slug: 'marketing-swarm',
+    purpose: 'Generate campaigns from curated feeds and project memory.',
+    inputs: ['Awesome ML & AI OPML feeds', 'X/Twitter discovery', 'Project tags'],
+    outputs: ['Post drafts', 'CTA blocks', 'Promo schedules'],
+    triggers: ['New feed items', 'Calendar beats'],
+  },
+  {
+    name: 'SEO SWARM',
+    slug: 'seo-swarm',
+    purpose: 'Deliver keywords, schema.org markup, and Ask Engine Optimization (AEO) assets.',
+    inputs: ['Site maps', 'Post drafts', 'X threads'],
+    outputs: ['Meta tags', 'JSON-LD documents', 'Alt text', 'Headline tests'],
+  },
+  {
+    name: 'MERCH Line SWARM (University + BeastCoast)',
+    slug: 'merch-line-swarm',
+    purpose: 'Coordinate print-on-demand plus AR/VR try-on experiences across dual stores.',
+    inputs: ['Product specs', 'Size tables', 'Mockups'],
+    outputs: ['Wix collections', 'AR assets (GLB/USDZ)', 'SEO content'],
+  },
+  {
+    name: 'Funnel Engine SWARM',
+    slug: 'funnel-engine-swarm',
+    purpose: 'Provide form builder, conditional logic, and analytics routing.',
+    inputs: ['Lead forms', 'UTM parameters', 'Experiment definitions'],
+    outputs: ['Dynamic routes', 'Feature flags', 'Dashboards'],
+  },
+  {
+    name: 'RSS LLM-ML Ingest SWARM',
+    slug: 'rss-llm-ml-swarm',
+    purpose: 'Process OPML feeds through FreshRSS and produce research briefs.',
+    inputs: ['arXiv ML', 'BAIR', 'MIT AI', 'Nvidia AI feeds'],
+    outputs: ['Briefs', 'Voiceover teasers', 'Prompt drills'],
+  },
+  {
+    name: 'Investor Showcase (Gamma)',
+    slug: 'investor-showcase-gamma',
+    purpose: 'Maintain Gamma demo pages featuring Neurodivergent HRM and status panels.',
+    inputs: ['Emergent LLM key', 'HRM schema'],
+    outputs: ['Gamma blocks', 'Investor-ready pages'],
+  },
+  {
+    name: 'Ticket Simulator / Ed-Trading SWARM',
+    slug: 'ticket-simulator-swarm',
+    purpose: 'Offer paper-trading modules and Telegram bot practice flows.',
+    inputs: ['Course modules', 'Simulated tokens ($CHAOS, $NEURO, $VRG)'],
+    outputs: ['Dashboards', 'Leaderboards', 'NFT-gated allocations'],
+  },
+  {
+    name: 'DBN → Barbed Wired Broadcasting',
+    slug: 'dbn-barbed-wired-broadcasting',
+    purpose: 'Produce newsdesk captions and maintain plushy Neuro anchor continuity.',
+    inputs: ['External feeds', 'Internal alerts'],
+    outputs: ['Short scripts', 'Overlay assets'],
+  },
+];
+
+function loadEnvFile(envFile) {
+  if (!envFile) {
+    return {};
+  }
+
+  const resolved = path.resolve(process.cwd(), envFile);
+  if (!fs.existsSync(resolved)) {
+    console.warn(`[orchestrator] Env file not found: ${resolved}`);
+    return {};
+  }
+
+  const content = fs.readFileSync(resolved, 'utf8');
+  const lines = content.split(/\r?\n/);
+  const env = {};
+
+  lines.forEach((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) {
+      return;
+    }
+
+    const eqIndex = trimmed.indexOf('=');
+    if (eqIndex === -1) {
+      return;
+    }
+
+    const key = trimmed.slice(0, eqIndex).trim();
+    const value = trimmed.slice(eqIndex + 1).trim();
+    env[key] = value;
+  });
+
+  return env;
+}
+
+function validateSecrets(env) {
+  const missing = REQUIRED_SECRETS.filter((key) => !env[key]);
+
+  const email = {
+    sendgrid: OPTIONAL_EMAIL.sendgrid.filter((key) => env[key]),
+    smtp: OPTIONAL_EMAIL.smtp.filter((key) => env[key]),
+  };
+
+  const emailStatus = {
+    sendgridConfigured: email.sendgrid.length === OPTIONAL_EMAIL.sendgrid.length,
+    smtpConfigured: email.smtp.length === OPTIONAL_EMAIL.smtp.length,
+    missing: [],
+  };
+
+  if (!emailStatus.sendgridConfigured && !emailStatus.smtpConfigured) {
+    emailStatus.missing = OPTIONAL_EMAIL.sendgrid.concat(OPTIONAL_EMAIL.smtp).filter((key) => !env[key]);
+  }
+
+  return {
+    missing,
+    emailStatus,
+  };
+}
+
+function discoverCanonicalPaths() {
+  const canonical = [
+    'apps/wix-sync-worker',
+    'apps/gamma',
+    'scripts',
+    '.github/workflows',
+    'docs/NOTION_DB_TEMPLATE.json',
+    'docs/WIREDCHAOS_PALETTE.md',
+  ];
+
+  return canonical.map((relativePath) => {
+    const absolutePath = path.join(ROOT_DIR, relativePath);
+    return {
+      path: relativePath,
+      exists: fs.existsSync(absolutePath),
+    };
+  });
+}
+
+function buildComponentGraph() {
+  const definitions = [
+    {
+      name: 'wix-sync-worker',
+      path: 'apps/wix-sync-worker',
+      buildCmd: 'node scripts/wix/build.js --tag ${version_tag}',
+      deployCmd: 'node scripts/wix/deploy.js --site $WIX_SITE_ID --tag ${version_tag} --canary ${canary_pct}',
+      dependencies: ['scripts/wix/build.js', 'scripts/wix/deploy.js'],
+    },
+    {
+      name: 'gamma-app',
+      path: 'apps/gamma',
+      buildCmd: 'pnpm -C apps/gamma install && pnpm -C apps/gamma build',
+      deployCmd: 'node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag ${version_tag} --canary ${canary_pct}',
+      dependencies: ['scripts/gamma/deploy.js'],
+    },
+    {
+      name: 'notion-sync-worker',
+      path: 'scripts/notion',
+      buildCmd: 'node scripts/notion/sync.js --dry-run',
+      deployCmd: 'node scripts/notion/sync.js',
+      dependencies: ['scripts/notion/sync.js'],
+    },
+  ];
+
+  return definitions.map((definition) => {
+    const absolutePath = path.join(ROOT_DIR, definition.path);
+    return {
+      ...definition,
+      exists: fs.existsSync(absolutePath),
+    };
+  });
+}
+
+function discoverAdditionalBots() {
+  const roots = ['apps', 'bots'];
+  const discovered = [];
+
+  roots.forEach((root) => {
+    const rootPath = path.join(ROOT_DIR, root);
+    if (!fs.existsSync(rootPath)) {
+      return;
+    }
+
+    const entries = fs.readdirSync(rootPath, { withFileTypes: true });
+    entries.forEach((entry) => {
+      if (!entry.isDirectory()) {
+        return;
+      }
+
+      const slug = `${root}-${entry.name}`;
+      if (DEFAULT_BOT_INVENTORY.some((bot) => bot.slug === slug)) {
+        return;
+      }
+
+      discovered.push({
+        name: entry.name,
+        slug,
+        path: path.join(root, entry.name),
+        purpose: 'Discovered automatically. Review to document purpose and integration points.',
+        inputs: [],
+        outputs: [],
+      });
+    });
+  });
+
+  return discovered;
+}
+
+function ensurePipeline(skipCreation) {
+  const pipelinePath = path.join(ROOT_DIR, 'codex.pipeline.yaml');
+  const exists = fs.existsSync(pipelinePath);
+
+  if (exists) {
+    return {
+      path: 'codex.pipeline.yaml',
+      created: false,
+    };
+  }
+
+  if (skipCreation) {
+    return {
+      path: 'codex.pipeline.yaml',
+      created: false,
+      skipped: true,
+    };
+  }
+
+  fs.writeFileSync(pipelinePath, createPipelineTemplate(), 'utf8');
+  return {
+    path: 'codex.pipeline.yaml',
+    created: true,
+  };
+}
+
+function createPipelineTemplate() {
+  return `version: 1\n` +
+    `name: wired-chaos-dual-canary\n` +
+    `description: >\n` +
+    `  Dual deploy pipeline orchestrated by Codex with staged canary ramps and SLO gates.\n` +
+    `inputs:\n` +
+    `  environment: staging\n` +
+    `  version_tag: HEAD\n` +
+    `stages:\n` +
+    `  - name: bootstrap\n` +
+    `    steps:\n` +
+    `      - run: node scripts/orchestrator/execute.js --summary-only\n` +
+    `        displayName: Orchestrator self-check\n` +
+    `  - name: deploy_wix\n` +
+    `    agent: wix/runner\n` +
+    `    steps:\n` +
+    `      - run: node scripts/wix/build.js --tag \${version_tag}\n` +
+    `      - run: node scripts/wix/deploy.js --site $WIX_SITE_ID --tag \${version_tag} --canary 5\n` +
+    `      - run: node scripts/swarm/log.js --event "wix:canary:5" --env \${environment}\n` +
+    `  - name: deploy_gamma\n` +
+    `    agent: gamma/runner\n` +
+    `    steps:\n` +
+    `      - run: pnpm -C apps/gamma install && pnpm -C apps/gamma build\n` +
+    `      - run: node scripts/gamma/deploy.js --space $GAMMA_SPACE_ID --tag \${version_tag} --canary 5\n` +
+    `      - run: node scripts/swarm/log.js --event "gamma:canary:5" --env \${environment}\n` +
+    `  - name: canary_ramp\n` +
+    `    agent: qa/canary-orchestrator\n` +
+    `    steps:\n` +
+    `      - run: node scripts/canary/shift.js --apps wix,gamma --pct 5\n` +
+    `      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99\n` +
+    `      - run: node scripts/swarm/log.js --event "canary:ramp:5" --env \${environment}\n` +
+    `      - run: node scripts/canary/shift.js --apps wix,gamma --pct 25\n` +
+    `      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99\n` +
+    `      - run: node scripts/swarm/log.js --event "canary:ramp:25" --env \${environment}\n` +
+    `      - run: node scripts/canary/shift.js --apps wix,gamma --pct 50\n` +
+    `      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99\n` +
+    `      - run: node scripts/swarm/log.js --event "canary:ramp:50" --env \${environment}\n` +
+    `      - run: node scripts/canary/shift.js --apps wix,gamma --pct 100\n` +
+    `      - run: node scripts/slo/check.js --apps wix,gamma --slo-url $NOTION_SLO_BADGE_URL --min 99\n` +
+    `      - run: node scripts/swarm/log.js --event "canary:ramp:100" --env \${environment}\n` +
+    `  - name: sync_and_finalize\n` +
+    `    steps:\n` +
+    `      - run: node scripts/notion/sync.js\n` +
+    `      - run: node scripts/flags/set.js --app wix --flag CanaryEnabled=false\n` +
+    `      - run: node scripts/flags/set.js --app gamma --flag CanaryEnabled=false\n` +
+    `      - run: node scripts/swarm/log.js --event "deploy:complete" --env \${environment}\n`;
+}
+
+function buildSummary({ env, secrets, canonicalPaths, componentGraph, botInventory, pipelineInfo }) {
+  return {
+    environment: env.environment || 'staging',
+    secrets,
+    canonicalPaths,
+    componentGraph,
+    botInventory,
+    pipeline: pipelineInfo,
+    canaryPlan: [5, 25, 50, 100],
+    sloGate: {
+      url: env.NOTION_SLO_BADGE_URL || null,
+      minimum: 99,
+    },
+    postDeployEvents: ['wix:canary:x', 'gamma:canary:x', 'canary:ramp:xx', 'deploy:complete'],
+    timestamp: new Date().toISOString(),
+  };
+}
+
+function printSummary(summary) {
+  console.log('=== Codex Orchestrator Summary ===');
+  console.log(`Environment: ${summary.environment}`);
+  console.log('--- Secrets ---');
+  if (summary.secrets.missing.length === 0) {
+    console.log('All required secrets present.');
+  } else {
+    console.log('Missing secrets:');
+    summary.secrets.missing.forEach((key) => console.log(`  - ${key}`));
+  }
+
+  if (summary.secrets.emailStatus.sendgridConfigured || summary.secrets.emailStatus.smtpConfigured) {
+    console.log('Email channel configured.');
+  } else {
+    console.log('Optional email configuration missing. Provide one of: SENDGRID_API_KEY or SMTP credentials.');
+  }
+
+  console.log('--- Canonical Paths ---');
+  summary.canonicalPaths.forEach((entry) => {
+    console.log(`${entry.exists ? '✓' : '✗'} ${entry.path}`);
+  });
+
+  console.log('--- Component Graph ---');
+  summary.componentGraph.forEach((component) => {
+    console.log(`${component.exists ? '✓' : '✗'} ${component.name} (${component.path})`);
+    console.log(`    build: ${component.buildCmd}`);
+    console.log(`    deploy: ${component.deployCmd}`);
+  });
+
+  console.log('--- Bot Inventory ---');
+  summary.botInventory.forEach((bot) => {
+    console.log(`• ${bot.name} [${bot.slug}]`);
+    console.log(`    Purpose: ${bot.purpose}`);
+    if (bot.path) {
+      console.log(`    Path: ${bot.path}`);
+    }
+  });
+
+  console.log('--- Pipeline ---');
+  const pipelineDetails = summary.pipeline;
+  if (pipelineDetails.created) {
+    console.log(`Materialized pipeline at ${pipelineDetails.path}`);
+  } else if (pipelineDetails.skipped) {
+    console.log('Pipeline creation skipped.');
+  } else {
+    console.log(`Pipeline already present at ${pipelineDetails.path}`);
+  }
+
+  console.log('--- Canary Plan ---');
+  console.log(summary.canaryPlan.join(' → ') + '%');
+
+  console.log('--- SLO Gate ---');
+  console.log(`URL: ${summary.sloGate.url || 'not configured'}`);
+  console.log(`Minimum: ${summary.sloGate.minimum}`);
+
+  console.log('--- Post-Deploy Events ---');
+  summary.postDeployEvents.forEach((evt) => console.log(`  - ${evt}`));
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const envFile = args['env-file'];
+  const skipPipeline = Boolean(args['skip-pipeline']);
+  const jsonOutput = args['json-output'];
+
+  const env = { ...process.env, ...loadEnvFile(envFile) };
+  if (args.environment) {
+    env.environment = args.environment;
+  }
+
+  const secrets = validateSecrets(env);
+  const canonicalPaths = discoverCanonicalPaths();
+  const componentGraph = buildComponentGraph();
+  const additionalBots = discoverAdditionalBots();
+  const botInventory = DEFAULT_BOT_INVENTORY.concat(additionalBots);
+  const pipelineInfo = ensurePipeline(skipPipeline);
+
+  const summary = buildSummary({ env, secrets, canonicalPaths, componentGraph, botInventory, pipelineInfo });
+
+  if (!args['summary-only']) {
+    printSummary(summary);
+  } else {
+    console.log('Summary generation completed (output suppressed by --summary-only).');
+  }
+
+  if (jsonOutput) {
+    const resolved = path.resolve(process.cwd(), jsonOutput);
+    writeReport(resolved, summary);
+  }
+}
+
+main();

--- a/scripts/orchestrator/lib/args.js
+++ b/scripts/orchestrator/lib/args.js
@@ -1,0 +1,51 @@
+'use strict';
+
+function parseArgs(argv) {
+  const args = {};
+  const positional = [];
+  let currentKey = null;
+
+  argv.forEach((token) => {
+    if (token.startsWith('--')) {
+      if (currentKey) {
+        args[currentKey] = true;
+      }
+
+      const trimmed = token.slice(2);
+      const eqIndex = trimmed.indexOf('=');
+
+      if (eqIndex !== -1) {
+        const key = trimmed.slice(0, eqIndex);
+        const value = trimmed.slice(eqIndex + 1);
+        args[key] = value;
+        currentKey = null;
+        return;
+      }
+
+      currentKey = trimmed;
+      return;
+    }
+
+    if (currentKey) {
+      args[currentKey] = token;
+      currentKey = null;
+      return;
+    }
+
+    positional.push(token);
+  });
+
+  if (currentKey) {
+    args[currentKey] = true;
+  }
+
+  if (positional.length > 0) {
+    args._ = positional;
+  }
+
+  return args;
+}
+
+module.exports = {
+  parseArgs,
+};

--- a/scripts/orchestrator/lib/report.js
+++ b/scripts/orchestrator/lib/report.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+function ensureDir(filePath) {
+  const dir = path.dirname(filePath);
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+  }
+}
+
+function writeReport(filePath, payload) {
+  if (!filePath) {
+    return;
+  }
+
+  ensureDir(filePath);
+  fs.writeFileSync(filePath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+}
+
+module.exports = {
+  writeReport,
+};

--- a/scripts/slo/check.js
+++ b/scripts/slo/check.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function parseApps(value) {
+  if (!value) {
+    return [];
+  }
+  return value.split(',').map((item) => item.trim()).filter(Boolean);
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const apps = parseApps(args.apps);
+  const sloUrl = args['slo-url'] || process.env.NOTION_SLO_BADGE_URL || 'not-provided';
+  const min = Number(args.min || 0);
+  const output = args['json-output'];
+
+  const result = {
+    action: 'slo-check',
+    apps,
+    sloUrl,
+    minimum: min,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub SLO check executed. Connect to monitoring provider when ready.',
+  };
+
+  console.log(`[slo-check] Validating SLO >= ${min} for apps: ${apps.join(', ') || 'none'} using ${sloUrl}`);
+  console.log('[slo-check] SLO check passed (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, result);
+  }
+}
+
+main();

--- a/scripts/swarm/log.js
+++ b/scripts/swarm/log.js
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const event = args.event || 'unspecified';
+  const env = args.env || process.env.environment || 'staging';
+  const data = args.data ? safeParse(args.data) : undefined;
+  const output = args['json-output'];
+
+  const payload = {
+    action: 'swarm-log',
+    event,
+    environment: env,
+    data: data || null,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub SWARM event logging. Connect to SWARM bridge when ready.',
+  };
+
+  console.log(`[swarm-log] event=${event} env=${env}`);
+  if (data) {
+    console.log(`[swarm-log] data=${JSON.stringify(data)}`);
+  }
+  console.log('[swarm-log] Log dispatched (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, payload);
+  }
+}
+
+function safeParse(raw) {
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    return { raw };
+  }
+}
+
+main();

--- a/scripts/wix/build.js
+++ b/scripts/wix/build.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const tag = args.tag || 'HEAD';
+  const output = args['json-output'];
+
+  const result = {
+    action: 'wix-build',
+    tag,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub build executed. Replace with real build process when available.',
+  };
+
+  console.log(`[wix-build] Preparing Wix assets for tag ${tag}`);
+  console.log('[wix-build] Build completed (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, result);
+  }
+}
+
+main();

--- a/scripts/wix/deploy.js
+++ b/scripts/wix/deploy.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+const { parseArgs } = require('../orchestrator/lib/args');
+const { writeReport } = require('../orchestrator/lib/report');
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const site = args.site || process.env.WIX_SITE_ID || 'unknown-site';
+  const tag = args.tag || 'HEAD';
+  const canary = Number(args.canary || 0);
+  const output = args['json-output'];
+
+  const result = {
+    action: 'wix-deploy',
+    site,
+    tag,
+    canary,
+    status: 'success',
+    timestamp: new Date().toISOString(),
+    notes: 'Stub deploy executed. Implement Wix deployment workflow when ready.',
+  };
+
+  console.log(`[wix-deploy] Deploying tag ${tag} to site ${site} at canary ${canary}%`);
+  console.log('[wix-deploy] Deployment completed (stub mode).');
+
+  if (output) {
+    const resolved = path.resolve(process.cwd(), output);
+    writeReport(resolved, result);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- introduce a reusable Codex orchestrator CLI that validates secrets, discovers components, and materializes the dual-canary pipeline
- add stub implementations for Wix, Gamma, canary, SLO, SWARM logging, flag toggles, and Notion sync commands used by the pipeline
- document the new automation workflow, provide a generated pipeline template, and include a sample orchestrator summary export

## Testing
- node scripts/orchestrator/execute.js --summary-only --json-output orchestrator-summary.json
- node scripts/orchestrator/execute.js --json-output orchestrator-check.json --skip-pipeline
- node scripts/wix/build.js --tag demo --json-output tmp/wix-build.json

------
https://chatgpt.com/codex/tasks/task_e_68e2de162598832fa7b4e0ea30a9dcb9