### PR TITLE
Fix component UI import paths

### DIFF
--- a/frontend/src/components/GrantsForFounders.js
+++ b/frontend/src/components/GrantsForFounders.js
@@ -15,8 +15,8 @@
 
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Card } from '../ui/card';
-import { Button } from '../ui/button';
+import { Card } from './ui/card';
+import { Button } from './ui/button';
 import '../App.css';
 
 const GrantsForFounders = () => {

--- a/frontend/src/components/PlaygroundHub.js
+++ b/frontend/src/components/PlaygroundHub.js
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import { Badge } from '../ui/badge';
-import { Button } from '../ui/button';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
-import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
+import { Badge } from './ui/badge';
+import { Button } from './ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
 import './PlaygroundHub.css';
 
 const PlaygroundHub = () => {


### PR DESCRIPTION
## Summary
- update GrantsForFounders component to import shared UI primitives from the correct relative path
- fix PlaygroundHub UI imports so the build can locate shared components

## Testing
- CI=true npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68e66e44421c832f865e76279b4794ff